### PR TITLE
Add structured docstrings

### DIFF
--- a/backend/src/main/survey.py
+++ b/backend/src/main/survey.py
@@ -11,6 +11,12 @@ import datetime
 class main:
     
     def sign_up():
+        """Prompt the user for account credentials.
+
+        Returns:
+            list: A list containing the email, username and password
+                entered by the user.
+        """
         
         questions = [
             "Email:",
@@ -27,8 +33,12 @@ class main:
         return answers  
                 
 
-    """This is the main class that will run the preliminary survey for the user and store it in the database."""
     def prelim_survey():
+        """Collect initial demographic and training information.
+
+        Returns:
+            list: Responses to all preliminary survey questions in order.
+        """
         
         
 
@@ -62,7 +72,11 @@ class main:
     # user_send.send_user_info(prelim_survey(), "postgres", "Control1500#")
 
     def daily_post_run_survey():
-        """This is the post run survey that will be used to gather data from the user after each run."""
+        """Gather feedback from the user after a training day.
+
+        Returns:
+            day_plan: A ``day_plan`` instance populated with the survey answers.
+        """
         questions = [
             "How would you rate this running using the RPE metric? (scale of 1-10):",
             "Was your daily mileage within the prescribed range:",
@@ -95,7 +109,11 @@ class main:
         print("Post-run survey completed. Thank you for your feedback!")
 
     def post_week_survey():
-        """This is the post week survey that will be used to gather data from the user after each week."""
+        """Gather feedback from the user after a training week.
+
+        Returns:
+            week_plan: A ``week_plan`` instance populated with the survey answer.
+        """
         questions = [
             "How would you rate this weeks worth of effort using the RPE metric? (scale of 1-10):"
         ]
@@ -113,7 +131,11 @@ class main:
         print("Post-week survey completed. Thank you for your feedback!")
 
     def post_month_survey():
-        """This is the post month survey that will be used to gather data from the user after each month."""
+        """Gather feedback from the user after a training month.
+
+        Returns:
+            month_plan: A ``month_plan`` instance populated with the survey answer.
+        """
         questions = [
             "How would you rate this months worth of effort using the RPE metric? (scale of 1-10):"
         ]

--- a/backend/src/utils/SQLutils/database_connect.py
+++ b/backend/src/utils/SQLutils/database_connect.py
@@ -1,3 +1,5 @@
+"""Helpers for connecting to and querying the PostgreSQL database."""
+
 import psycopg2
 import logging
 from psycopg2.extras import register_composite
@@ -8,6 +10,18 @@ from backend.src.utils.SQLutils.config import DB_CREDENTIALS
 
 
 def init_db(username, pwd):
+    """Create a connection to the PostgreSQL database.
+
+    Args:
+        username (str): Database username.
+        pwd (str): Password for the given username.
+
+    Returns:
+        connection | None: A connection instance on success, otherwise ``None``.
+
+    Raises:
+        psycopg2.Error: If the connection attempt fails.
+    """
     try:
         if (username != "postgres"):
             locate = DB_CREDENTIALS["host"]
@@ -27,16 +41,18 @@ def init_db(username, pwd):
         return None
 
 def db_select(curr, query, user_id):
-    """
-    Executes a SQL query to select data for a specific user ID.
-    
-    Parameters:
-    - curr: The database cursor.
-    - query: The SQL query to execute.
-    - user_id: The user ID to filter the query.
-    
+    """Execute ``query`` using ``user_id`` as a parameter.
+
+    Args:
+        curr (cursor): Active database cursor.
+        query (str): Parameterized SQL query.
+        user_id (int): Target user identifier.
+
     Returns:
-    - The fetched results from the executed query.
+        list | None: Query results or ``None`` if execution fails.
+
+    Raises:
+        psycopg2.Error: If execution of the query fails.
     """
     try:
         # Fill the query with the user ID
@@ -49,10 +65,32 @@ def db_select(curr, query, user_id):
         return None
 
 
-# Takes in prelim survey datapoints and inserts them into the SQL database
 def db_insert(curr, user_id, dob, sex, runningex, injury,
               most_recent_injury, longest_run, goal_date, pace_estimate,
               available_days, number_of_days, workout_rpe):
+    """Insert a user into ``userlistai``.
+
+    Args:
+        curr (cursor): Active database cursor.
+        user_id (int): User identifier.
+        dob (str): Date of birth.
+        sex (str): Sex of the user.
+        runningex (str): Running experience level.
+        injury (int): Number of significant injuries.
+        most_recent_injury (int): Months since most recent injury.
+        longest_run (int): Longest run distance.
+        goal_date (str): Primary goal race date.
+        pace_estimate (list): Serialized list of pace estimates.
+        available_days (list): Days available for training.
+        number_of_days (int): Desired running days per week.
+        workout_rpe (str): JSON string of workout RPE values.
+
+    Returns:
+        None
+
+    Raises:
+        psycopg2.Error: If the INSERT fails.
+    """
     # write query
     query = """ INSERT INTO public.userlistai(
         user_id, dob, sex, runningex, injury, most_recent_injury, longest_run, 
@@ -72,6 +110,21 @@ def db_insert(curr, user_id, dob, sex, runningex, injury,
 def db_update(curr, user_id, dob, sex, runningex, injury,
               most_recent_injury, longest_run, goal_date, pace_estimate,
               available_days, number_of_days, workout_rpe):
+    """Update an existing row in ``userlistai``.
+
+    Args:
+        curr (cursor): Active database cursor.
+        user_id (int): Identifier of the user record to update.
+        dob, sex, runningex, injury, most_recent_injury, longest_run,
+        goal_date, pace_estimate, available_days, number_of_days,
+        workout_rpe: See :func:`db_insert` for parameter descriptions.
+
+    Returns:
+        None
+
+    Raises:
+        psycopg2.Error: If the UPDATE fails.
+    """
     # write query
     query = """ UPDATE public.userlistai
         SET dob= %s, sex= %s, runningex= %s, injury= %s, most_recent_injury= %s, 

--- a/backend/src/utils/SQLutils/user_send.py
+++ b/backend/src/utils/SQLutils/user_send.py
@@ -11,10 +11,15 @@ from queue import Empty
 import json
 
 def send_user_info(new_user, curr):
-    """Sends user information to the database. If the user already exists, updates their information; otherwise, inserts a new record.
-    Args: 
-        new_user (User): An instance of the User class containing user information.
-        curr (cursor): The database cursor to execute SQL commands."""
+    """Insert or update the primary user record.
+
+    Args:
+        new_user (user): User object containing information to store.
+        curr (cursor): Active database cursor.
+
+    Returns:
+        None
+    """
         
     # Check if user already exists
     check_query = """SELECT 1 FROM public.userlistai WHERE user_id = %s;"""
@@ -42,10 +47,15 @@ def send_user_info(new_user, curr):
         )
 
 def send_month_cycle(new_user, curr):
-    """Send month cycle data to the database.
+    """Insert month plans for ``new_user``.
+
     Args:
-        new_user (User): An instance of the User class containing user information.
-        curr (cursor): The database cursor to execute SQL commands.
+        new_user (user): User instance whose ``month_history`` and ``month_future`` contain
+            month plans to send.
+        curr (cursor): Active database cursor.
+
+    Returns:
+        None
     """
     
     query = """ INSERT INTO public.month_cycle(
@@ -79,10 +89,14 @@ def send_month_cycle(new_user, curr):
         
 
 def send_week_cycle(new_user, curr):
-    """Send week cycle data to the database.
+    """Insert week plans for ``new_user``.
+
     Args:
-        new_user (User): An instance of the User class containing user information.
-        curr (cursor): The database cursor to execute SQL commands.
+        new_user (user): User instance containing week plan history and future queues.
+        curr (cursor): Active database cursor.
+
+    Returns:
+        None
     """
 
     query = """ INSERT INTO public.week_cycle(
@@ -117,6 +131,16 @@ def send_week_cycle(new_user, curr):
 
 # populate day cycle user infomation within SQL database
 def send_day_cycle(new_user, curr, TrioType):
+    """Persist day plans for ``new_user``.
+
+    Args:
+        new_user (user): User instance containing ``day_history`` and ``day_future`` stacks.
+        curr (cursor): Active database cursor.
+        TrioType (type): Registered composite representing a trio.
+
+    Returns:
+        None
+    """
 
     query = """ INSERT INTO public.day_cycle(
         user_id, day_id, total_mileage, goal_stimuli, lift, expected_rpe, real_rpe, 
@@ -156,18 +180,19 @@ def send_day_cycle(new_user, curr, TrioType):
 
 
 def send_user_creds(user_id, username, password, login_info):
-    """
-    Sends user credentials to the database. If the user already exists, 
-    updates their credentials; otherwise, inserts a new record.
+    """Insert or update the user's login credentials.
 
     Args:
-        user_id (int): The unique identifier for the user.
-        username (str): The username of the user.
-        password (str): The password of the user.
-        login_info (dict): A dictionary containing 'email', 'username', and 'password' keys.
+        user_id (int): Identifier for the user.
+        username (str): Database username used for the connection.
+        password (str): Password for ``username``.
+        login_info (dict): Mapping containing ``email``, ``username`` and ``password`` keys.
+
+    Returns:
+        None
 
     Raises:
-        Exception: If there is an error during the database operation.
+        Exception: If any database operation fails.
     """
 
     conn = init_db(username, password)
@@ -212,7 +237,16 @@ def send_user_creds(user_id, username, password, login_info):
 
 
 def send_user_all(user, username, password):
+    """Persist all structures associated with ``user``.
 
+    Args:
+        user (user): User instance whose data is being stored.
+        username (str): Database username.
+        password (str): Database password.
+
+    Returns:
+        None
+    """
     try:
         conn = init_db(username, password)
         curr = conn.cursor()
@@ -241,5 +275,14 @@ def send_user_all(user, username, password):
 
 
 def cast_workouts_to_trios(workouts, TrioType):
+    """Convert raw workout tuples to ``Trio`` composites.
+
+    Args:
+        workouts (list): List of ``(stim, rpe, dist)`` tuples.
+        TrioType (type): Registered composite representing a trio.
+
+    Returns:
+        list: List of ``TrioType`` objects.
+    """
 
     return [TrioType(*triplet) for triplet in workouts]

--- a/backend/src/utils/decision_tree.py
+++ b/backend/src/utils/decision_tree.py
@@ -10,9 +10,19 @@ from backend.src.utils.user_storage.user import user
 class decision_tree:
 
     def __init__(self, user):
+        """Store the :class:`user` under evaluation.
+
+        Args:
+            user (user): Instance containing attributes used for plan selection.
+        """
         self.user = user
 
     def get_decision_tree(self):
+        """Return the training plan index chosen for ``self.user``.
+
+        Returns:
+            int: Index of the plan within :func:`training_plan_array`.
+        """
         plans = training_plan_array()
         # NAMING CONVENTION:
         # age_sex_level_injury_injuryHistory_injuryRecent_longestLongRun

--- a/backend/src/utils/pace_calculations.py
+++ b/backend/src/utils/pace_calculations.py
@@ -14,7 +14,18 @@ TIME_CONVERSION_NUM = 60
 
 @staticmethod
 def get_VDOT(dist: float, time: float) -> float:
-    """return the VDOT value of a runner given the distance in meters and time in seconds."""
+    """Return the VDOT value of a runner.
+
+    Args:
+        dist (float): Distance in meters.
+        time (float): Time in seconds.
+
+    Returns:
+        float: Calculated VDOT value.
+
+    Raises:
+        ValueError: If ``dist`` or ``time`` are non-positive.
+    """
     if dist <= 0 or time <= 0:
         raise ValueError("Distance and time must be positive values.")
     time_min = time / 60  # Convert time to minutes
@@ -31,6 +42,16 @@ def get_VDOT(dist: float, time: float) -> float:
 
 @staticmethod
 def get_training_pace_helper(race_dist: float, race_time: float, pct_pace: float) -> float:
+    """Calculate a target pace from race performance.
+
+    Args:
+        race_dist (float): Race distance in meters.
+        race_time (float): Completion time in seconds.
+        pct_pace (float): Desired training pace as a percentage of VDOT pace.
+
+    Returns:
+        float: Target pace in seconds per mile.
+    """
     vdot = get_VDOT(race_dist, race_time)
     target = round((MILE * 2 * 0.000104)/(-0.182258 + math.sqrt(0.182258 **
                    2 - 4 * 0.000104*(-4.6 - pct_pace * vdot))) * 60)
@@ -45,7 +66,14 @@ def get_training_pace_helper(race_dist: float, race_time: float, pct_pace: float
 
 @staticmethod
 def to_str(sec: int) -> str:
-    """ Convert seconds to a string in the format H:MM:SS."""
+    """Convert seconds to ``H:MM:SS`` format.
+
+    Args:
+        sec (int): Number of seconds.
+
+    Returns:
+        str: Time string.
+    """
     minutes = (math.floor(sec/TIME_CONVERSION_NUM) %
                TIME_CONVERSION_NUM)  # Get the number of minutes
     hours = math.floor(sec/(TIME_CONVERSION_NUM*TIME_CONVERSION_NUM)
@@ -62,7 +90,14 @@ def to_str(sec: int) -> str:
 
 @staticmethod
 def from_str(pace: str) -> int:
-    """ Convert pace in the format H:MM:SS to seconds."""
+    """Convert pace from ``H:MM:SS`` format to seconds.
+
+    Args:
+        pace (str): Pace string.
+
+    Returns:
+        int: Total seconds.
+    """
     times = pace.split(":")  # Split the string to
     multiplier = 1  # Prepare the multiplier for conversion
     total = 0  # Total seconds
@@ -75,7 +110,7 @@ def from_str(pace: str) -> int:
 
 @staticmethod
 def from_dec(pace: float) -> str:
-    """ Convert decimal pace to a string in the format M:SS."""
+    """Convert decimal pace to ``M:SS`` string."""
     dec = math.floor(
         (pace % 1) * TIME_CONVERSION_NUM)  # Get the decimal part in seconds
     val = math.floor(pace)  # Get the integer part in minutes
@@ -84,7 +119,15 @@ def from_dec(pace: float) -> str:
 
 @staticmethod
 def total_time_miles(pace, mile: int) -> int:
-    """ Calculate the total time in seconds for a given pace (in seconds per mile) and distance (in miles)."""
+    """Return total time for ``mile`` miles at ``pace`` seconds per mile.
+
+    Args:
+        pace (int | str): Pace in seconds or ``H:MM:SS`` format.
+        mile (int): Distance in miles.
+
+    Returns:
+        int: Total time in seconds.
+    """
     if isinstance(pace, str):  # If pace is a string, convert it to seconds
         pace = from_str(pace)
     return total_time(pace, (mile * MILE))
@@ -92,7 +135,15 @@ def total_time_miles(pace, mile: int) -> int:
 
 @staticmethod
 def total_time(pace, distance: int) -> int:
-    """ Calculate the total time in seconds for a given pace (in seconds per mile) and distance (in meters)."""
+    """Return total time for ``distance`` meters at ``pace`` seconds per mile.
+
+    Args:
+        pace (int | str): Pace in seconds or ``H:MM:SS`` format.
+        distance (int): Distance in meters.
+
+    Returns:
+        int: Time in seconds.
+    """
     if isinstance(pace, str):  # If pace is a string, convert it to seconds
         pace = from_str(pace)
     return math.floor((pace * distance) / MILE)
@@ -100,6 +151,18 @@ def total_time(pace, distance: int) -> int:
 
 @staticmethod
 def mile_pace(pace, distance: int) -> int:
+    """Return the pace per mile for a given distance.
+
+    Args
+    ----
+    pace : int | str
+        Pace in seconds or ``H:MM:SS`` format.
+    distance : int
+        Distance in meters.
+
+    Returns:
+        int: Pace in seconds per mile.
+    """
     if distance == 0:  # If distance is 0, return 0 to avoid division by zero
         return 0
     if isinstance(pace, str):  # If pace is a string, convert it to seconds

--- a/backend/src/utils/user_creation.py
+++ b/backend/src/utils/user_creation.py
@@ -10,10 +10,18 @@ USERNAME_LOC, PASSWORD_LOC = 0, 1
 PASS_LEN_REQ = 8
 
 
-""" this function takes in the email string and checks for correct formatting """
+"""Utility validation helpers."""
 
 
 def validate_address(email: str):
+    """Check whether ``email`` is syntactically valid.
+
+    Args:
+        email (str): Email address to validate.
+
+    Returns:
+        bool: ``True`` if the address is valid, ``False`` otherwise.
+    """
     try:
         validate_email(email)
         return True
@@ -99,8 +107,14 @@ long term storage and security. In an the event an SQL query fails, the function
 
 
 def credential_check(username: str, password: str) -> bool:
-    """ A function that checks if the username and password combination exists in the database.
-    Returns the user_id if the credentials are valid, 0 if no user is found with that username
+    """Verify a username/password pair.
+
+    Args:
+        username (str): Account username.
+        password (str): Plain text password.
+
+    Returns:
+        int | bool: ``user_id`` if credentials are valid, ``0`` otherwise.
     """
 
     # initialize the database connection
@@ -142,9 +156,14 @@ def credential_check(username: str, password: str) -> bool:
 
 
 def user_exists(user_credentials) -> tuple:
-    """Checks if the user exists in the database.
-    If the user exists, returns True and an error code (1 for email, 0 for username).
-    If the user does not exist, returns False and a user_id.
+    """Check whether a user already exists.
+
+    Args:
+        user_credentials (dict): Dictionary with ``email`` and ``username`` keys.
+
+    Returns:
+        tuple: ``(True, code)`` if user exists (``code`` 1 for email conflict,
+        0 for username). ``(False, user_id)`` otherwise.
     """
     conn = init_db(DB_CREDENTIALS["DB_USERNAME"],
                    DB_CREDENTIALS["DB_PASSWORD"])
@@ -185,8 +204,15 @@ def user_exists(user_credentials) -> tuple:
 
 
 def forgot_password(username: str, new_password: str, email: str) -> bool:
-    """ A function that resets the password for a user.
-    Returns True if successful, False otherwise.
+    """Reset a user's password.
+
+    Args:
+        username (str): Username to update.
+        new_password (str): New password in plain text.
+        email (str): Email used for verification.
+
+    Returns:
+        bool: ``True`` if the reset succeeded, ``False`` otherwise.
     """
 
     # checks if the user exists in the database

--- a/backend/src/utils/user_storage/day_plan.py
+++ b/backend/src/utils/user_storage/day_plan.py
@@ -9,8 +9,26 @@ class day_plan:
     __slots__ = ("total_mileage", "completed_mileage", "goal_stimuli",
                  "lift", "expected_rpe", "real_rpe", "percent_completion", "workouts", "week_id", "day_id")
 
-    def __init__(self, workouts: list = [], total_mileage: int = -1, lift: bool = False, expected_rpe=-1, week_id: int = -1,
-                 real_rpe: int = 0, completed_mileage: int = 0, percent_completion: int = 0, day_id=-1, goal_stimuli=workout_database.create_trio(-1, -1, -1)):
+    def __init__(self, workouts: list = None, total_mileage: int = -1,
+                 lift: bool = False, expected_rpe: int = -1,
+                 week_id: int = -1, real_rpe: int = 0,
+                 completed_mileage: int = 0, percent_completion: int = 0,
+                 day_id: int = -1,
+                 goal_stimuli=workout_database.create_trio(-1, -1, -1)):
+        """Initialize a day within a training plan.
+
+        Args:
+            workouts (list, optional): List of workout trios for the day.
+            total_mileage (int, optional): Planned mileage for the day.
+            lift (bool, optional): Whether the day includes lifting.
+            expected_rpe (int, optional): Anticipated RPE value.
+            week_id (int, optional): Identifier of the parent week.
+            real_rpe (int, optional): Actual recorded RPE.
+            completed_mileage (int, optional): Mileage completed so far.
+            percent_completion (int, optional): Completion percentage of the day.
+            day_id (int, optional): Unique identifier for the day.
+            goal_stimuli (tuple, optional): Trio describing the goal stimulus for the day.
+        """
 
         self.day_id = day_id  # Unique identifier for the day
         self.lift = lift  # Boolean indicating if the day is a lifting day
@@ -40,7 +58,19 @@ class day_plan:
 
     @staticmethod
     def __make_stimuli_trio(workouts: list) -> tuple:
-        """ Create a trio used to define the week using the trios from workouts"""
+        """Aggregate individual workout trios into a day-level trio.
+
+        Args
+        ----
+        workouts : list
+            List of workout trios.
+
+        Returns
+        -------
+        tuple
+            Trio representing the maximum stimulus, maximum RPE and total
+            distance for the day.
+        """
         tot_stim, tot_rpe, tot_dist = 0, 0, 0
         for trios in workouts:
             # Only consider the stimuli if the distance > 1 (Ignore warmup/cooldown)
@@ -53,31 +83,61 @@ class day_plan:
         return workout_database.create_trio(tot_stim, tot_rpe, tot_dist)
 
     def add_workouts(self, *workouts) -> None:
-        """ Add multiple workouts to the day plan"""
+        """Add multiple workouts to the day plan.
+
+        Args
+        ----
+        *workouts : tuple
+            Workout trios to append.
+        """
         for workout in workouts:
             self.workouts.append(workout)
 
     def update__real_rpe(self, real_rpe: int) -> None:
-        """ Update the real RPE for the day"""
+        """Update the recorded RPE for the day.
+
+        Args
+        ----
+        real_rpe : int
+            Actual perceived effort.
+        """
         self.real_rpe = real_rpe
 
     def update_daily_mileage(self, mileage: int) -> None:
-        """ Update the completed mileage for the day"""
+        """Set the completed mileage for the day and recalc percentage.
+
+        Args
+        ----
+        mileage : int
+            Total miles run.
+        """
         self.completed_mileage = mileage
         self.update_daily_percentage()  # Update the completion percentage
 
     def update_daily_percentage(self) -> None:
-        """ Update the completion percentage based on the total and completed mileage"""
+        """Recalculate ``percent_completion`` based on mileage."""
         self.percent_completion = self.completed_mileage / \
             self.total_mileage if self.total_mileage > 0 else 1
 
     # Note that updating mileage also updates the percentage
     def update_day(self, mileage: int, real_rpe: int) -> None:
-        """ Update the daily mileage and RPE"""
+        """Convenience method to update mileage and RPE."""
         self.update_daily_mileage(mileage)
         self.update__real_rpe(real_rpe)
 
     def __eq__(self, other) -> bool:
+        """Return ``True`` if two day plans have identical attributes.
+
+        Args
+        ----
+        other : day_plan
+            Day plan to compare against.
+
+        Returns
+        -------
+        bool
+            ``True`` if equal, ``False`` otherwise.
+        """
         if (self.total_mileage != other.total_mileage or
                 self.completed_mileage != other.completed_mileage or
                 self.lift != other.lift or
@@ -92,6 +152,7 @@ class day_plan:
         return True
 
     def __repr__(self) -> str:
+        """Return debug representation of the day plan."""
         return (
             f"day_id: {self.day_id}, week_id: {self.week_id}, "
             f"total_mileage: {self.total_mileage}, completed_mileage: {self.completed_mileage}, "

--- a/backend/src/utils/user_storage/month_plan.py
+++ b/backend/src/utils/user_storage/month_plan.py
@@ -7,22 +7,38 @@ class month_plan:
     __slots__ = ("month_id", "total_mileage", "goal_stimuli", "cycle", "weeks",
                  "percent_completion", "completed_mileage", "expected_rpe", "real_rpe")
 
-    def __init__(self, month_id: int = -1, total_mileage: int = 0, goal_stimuli=workout_database.create_trio(0, 0, 0), cycle: str = "", expected_rpe: int = 0, real_rpe: int = 0, completed_mileage: int = 0, percent_completion: int = 0, weeks: list | None = None):
-        """_summary_
+    def __init__(self, month_id: int = -1, total_mileage: int = 0,
+                 goal_stimuli=workout_database.create_trio(0, 0, 0),
+                 cycle: str = "", expected_rpe: int = 0, real_rpe: int = 0,
+                 completed_mileage: int = 0, percent_completion: int = 0,
+                 weeks: list | None = None):
+        """Initialize a month within a training cycle.
 
-        Args:
-            month_id (int, optional): _description_. Defaults to -1.
-            total_mileage (int, optional): _description_. Defaults to 0.
-            goal_stimuli (_type_, optional): _description_. Defaults to workout_database.create_trio(0, 0, 0).
-            cycle (str, optional): _description_. Defaults to "".
-            expected_rpe (int, optional): _description_. Defaults to 0.
-            real_rpe (int, optional): _description_. Defaults to 0.
-            completed_mileage (int, optional): _description_. Defaults to 0.
-            percent_completion (int, optional): _description_. Defaults to 0.
-            weeks (list, optional): _description_. Defaults to [].
+        Args
+        ----
+        month_id : int, optional
+            Identifier for the month.
+        total_mileage : int, optional
+            Planned mileage for the month.
+        goal_stimuli : tuple, optional
+            Trio describing the month's goal stimulus.
+        cycle : str, optional
+            Name of the training cycle (build, taper, etc.).
+        expected_rpe : int, optional
+            Expected RPE for the month.
+        real_rpe : int, optional
+            Actual average RPE.
+        completed_mileage : int, optional
+            Completed mileage so far.
+        percent_completion : int, optional
+            Completion percentage.
+        weeks : list, optional
+            List of :class:`week_plan` objects.
 
-        Raises:
-            TypeError: _description_
+        Raises
+        ------
+        TypeError
+            If ``weeks`` contains objects that are not ``week_plan`` instances.
         """
         self.weeks = weeks if weeks is not None else []
         for week in self.weeks:  # Ensure that each week is of type week_plan
@@ -90,6 +106,7 @@ class month_plan:
                 all(week1 == week2 for week1, week2 in zip(self.weeks, other.weeks)))
 
     def __repr__(self) -> str:
+        """Return debug representation of the month plan."""
         return (
             f"month_plan("
             f"month_id={self.month_id!r}, "

--- a/backend/src/utils/user_storage/storage_stacks_and_queues.py
+++ b/backend/src/utils/user_storage/storage_stacks_and_queues.py
@@ -9,7 +9,7 @@ class storage_stacks_and_queues:
                  "month_future", "week_future", "day_future")
 
     def __init__(self):
-        # Initialize the storage class
+        """Create empty stacks and queues for plan history and future."""
         # stacks
         self.month_history = deque()
         self.week_history = deque()

--- a/backend/src/utils/user_storage/training.py
+++ b/backend/src/utils/user_storage/training.py
@@ -7,6 +7,17 @@ class training:
     __slots__ = ("daily", "weekly", "monthly")
 
     def __init__(self, daily: day_plan, weekly: week_plan, monthly: month_plan):
+        """Container holding the current day, week and month plans.
+
+        Args
+        ----
+        daily : day_plan
+            Current day plan.
+        weekly : week_plan
+            Current week plan.
+        monthly : month_plan
+            Current month plan.
+        """
         self.daily = daily
         self.weekly = weekly
         self.monthly = monthly

--- a/backend/src/utils/user_storage/training_database.py
+++ b/backend/src/utils/user_storage/training_database.py
@@ -8,6 +8,13 @@ class training_database:
     _instance_ = None
 
     def __new__(cls):
+        """Create or return the singleton instance.
+
+        Returns
+        -------
+        training_database
+            The shared training database instance.
+        """
         if cls._instance_ is None:
             cls._instance_ = super(training_database, cls).__new__(cls)
             # Initialize the instance

--- a/backend/src/utils/user_storage/user.py
+++ b/backend/src/utils/user_storage/user.py
@@ -114,12 +114,14 @@ class user:
     # Returns the mile pace for each distance.
 
     def get_times(self) -> str:
+        """Return all predicted pace times as newline separated string."""
         toReturn = ""
         for pace in self.pace_estimates:
             toReturn += f"{to_str(pace)}\n"
         return toReturn
 
     def get_user_id(self) -> int:
+        """Return the unique identifier for this user."""
         return self.user_id
 
     def user_id_exists(user_id: int) -> bool:
@@ -167,26 +169,46 @@ class user:
         return age
 
     def append_month(self, month):
+        """Append a completed month to history."""
         self.month_history.append(month)
 
     def append_fut_month(self, month):
+        """Queue a future month plan."""
         self.month_future.put(month)
 
     def append_week(self, week):
+        """Append a completed week to history."""
         self.week_history.append(week)
 
     def append_fut_week(self, week):
+        """Queue a future week plan."""
         self.week_future.put(week)
 
     def append_day(self, day):
+        """Append a completed day to history."""
         self.day_history.append(day)
 
     def append_fut_day(self, day):
+        """Queue a future day plan."""
         self.day_future.put(day)
 
         # Takes in a string and a user i.e. (5000+10, 17:30 5k runner) and returns the pace associated with it.
 
     def modify_pace(self, change: int, distance: int) -> int:
+        """Adjust a stored pace value.
+
+        Args
+        ----
+        change : int
+            Number of seconds to add or subtract.
+        distance : int
+            Index of the pace to modify.
+
+        Returns
+        -------
+        int
+            Updated pace in seconds.
+        """
         return self.pace_estimates[distance] + change
 
     def get_training_pace(self, workout_type: int) -> int:
@@ -259,6 +281,7 @@ class user:
         # self.workout_RPE == other.workout_RPE) # Should add workoutRPE check and possibly storage
 
     def __repr__(self) -> str:
+        """Return a developer friendly representation of the user."""
         return (
             f"user("
             f"user_id={self.user_id!r}, dob={self.dob!r}, sex={self.sex!r}, running_ex={self.running_ex!r},\n"

--- a/backend/src/utils/user_storage/week_plan.py
+++ b/backend/src/utils/user_storage/week_plan.py
@@ -88,6 +88,7 @@ class week_plan:
                 )
 
     def __repr__(self) -> str:
+        """Return debug representation of the week plan."""
         return (
             f"week_plan("
             f"week_id={self.week_id!r}, "

--- a/backend/src/utils/workout/single_workout.py
+++ b/backend/src/utils/workout/single_workout.py
@@ -10,6 +10,19 @@ class single_workout:
     # pace = list of strings (pace type: 5k, easy, mile, etc.)
     # distance = % of total long run distance (1-100)
     def __init__(self, trio: tuple, reps: list, pace: list, distance: int):
+        """Create a workout from a trio and accompanying details.
+
+        Args
+        ----
+        trio : tuple
+            ``(stim, rpe, dist)`` tuple describing the workout.
+        reps : list
+            List of repetition distances.
+        pace : list
+            Pace description strings.
+        distance : int
+            Percentage of the long run distance.
+        """
         self.trio = trio
         self.reps = reps
         self.pace = pace
@@ -17,11 +30,19 @@ class single_workout:
 
     @staticmethod
     def trio_equal(trio_1: tuple, trio_2: tuple) -> bool:
+        """Return ``True`` if two trios are identical."""
         return trio_1[TRIO_STIM] == trio_2[TRIO_STIM] and \
             trio_1[TRIO_RPE] == trio_2[TRIO_RPE] and \
             trio_1[TRIO_DIST] == trio_2[TRIO_DIST]
 
     def get_trio(self) -> tuple:
+        """Return the underlying trio.
+
+        Returns
+        -------
+        tuple
+            ``(stim, rpe, dist)`` for this workout.
+        """
         return self.trio
 
     def get_stim(self) -> float:
@@ -49,4 +70,5 @@ class single_workout:
         return self.reps
 
     def __str__(self) -> str:
+        """Return a human readable representation of the workout."""
         return f"Workout: {self.trio}, Reps: {self.reps}, Pace: {self.pace}, Distance: {self.distance}"

--- a/backend/src/utils/workout/workout_database.py
+++ b/backend/src/utils/workout/workout_database.py
@@ -12,11 +12,24 @@ class workout_database:
     # Creates a trio that can be used as a key in the workout dictionary.
     @staticmethod
     def create_trio(stim, rpe, dist) -> tuple:
+        """Return a normalized trio of stimulus, RPE and distance.
+
+        Args
+        ----
+        stim, rpe, dist : float
+            Components of the trio.
+
+        Returns
+        -------
+        tuple
+            ``(stim, rpe, dist)`` as floats.
+        """
         stim, rpe, dist = float(stim), float(rpe), float(dist)
         return (stim, rpe, dist)
 
     @staticmethod
     def workout_trio_equal(workout_1: single_workout, workout_2: single_workout) -> bool:
+        """Return ``True`` if the workouts have identical trio values."""
         return single_workout.trio_equal(workout_1.get_trio(), workout_2.get_trio())
 
     # x range is 1 - 7 stimulus, y range is 1 -10 RPE, z range is 1 - 10 Distance
@@ -41,6 +54,15 @@ class workout_database:
                  long: list = [], threshold: list = [], fartlek: list = [],
                  race_pace_interval: list = [], strides: list = [], hill_sprints: list = [],
                  flat_sprints: list = [], time_trial: list = [], warmup_and_cooldown: list = []):
+        """Create a workout database backed by the shared :class:`workout_storage`.
+
+        Args
+        ----
+        easyrun, recovery, kenyan, long, threshold, fartlek,
+        race_pace_interval, strides, hill_sprints, flat_sprints,
+        time_trial, warmup_and_cooldown : list, optional
+            Initial workouts for each category.
+        """
 
         # Set up the collection of workouts of each type
         self.easyrun = workout_database.storage.easyrun
@@ -91,7 +113,13 @@ class workout_database:
                            list.append, workout)
 
     def mass_add_workouts(self, workouts) -> None:
-        """"Add a list of workouts to the database"""
+        """Add multiple workouts to the database.
+
+        Args
+        ----
+        workouts : iterable
+            Sequence of :class:`single_workout` objects.
+        """
         for workout in workouts:
             self.add_workout(workout)
             # try:
@@ -158,6 +186,18 @@ class workout_database:
         return final_workout
 
     def get_individual_workout(self, stim: float, rpe: float, dist: float) -> single_workout:
+        """Return the closest matching workout for the provided trio.
+
+        Args
+        ----
+        stim, rpe, dist : float
+            Coordinates describing the desired workout.
+
+        Returns
+        -------
+        single_workout
+            Closest workout stored in the database.
+        """
         workout_type = self.get_workout_type(
             stim, rpe, dist)  # Get the workout type based on the trio
         # Find the closest workout within the particular database
@@ -191,4 +231,5 @@ class workout_database:
             (dist - workout_trio[TRIO_DIST]))
 
     def get_distance(trio: tuple, stim: float, rpe: float, dist: float) -> float:
+        """Return squared distance between ``trio`` and input coordinates."""
         return (trio[TRIO_STIM] - stim) ** 2 + (trio[TRIO_RPE] - rpe) ** 2 + (trio[TRIO_DIST] - dist) ** 2

--- a/backend/src/utils/workout/workout_storage.py
+++ b/backend/src/utils/workout/workout_storage.py
@@ -8,6 +8,7 @@ class workout_storage:
     # Initialize the workout storage with empty lists for threshold and interval workouts.
 
     def __init__(self):
+        """Initialize empty lists for each workout type."""
         self.easyrun = []
         self.recovery = []
         self.kenyan = []
@@ -24,48 +25,60 @@ class workout_storage:
     # Getters for the workout lists
     # get et workouts
     def get_easyrun_workouts(self) -> list:
+        """Return the list of easy run workouts."""
         return self.easyrun
     # get recovery workouts
 
     def get_recovery_workouts(self) -> list:
+        """Return the list of recovery workouts."""
         return self.recovery
     # get kenyan workouts
 
     def get_kenyan_workouts(self) -> list:
+        """Return the list of progression workouts."""
         return self.kenyan
     # get long workouts
 
     def get_long_workouts(self) -> list:
+        """Return the list of long run workouts."""
         return self.long
     # get threshold workouts
 
     def get_threshold_workouts(self) -> list:
+        """Return the list of threshold workouts."""
         return self.threshold
     # get fartlek workouts
 
     def get_fartlek_workouts(self) -> list:
+        """Return the list of fartlek workouts."""
         return self.fartlek
     # get race pace interval workouts
 
     def get_race_pace_interval_workouts(self) -> list:
+        """Return race pace interval workouts."""
         return self.race_pace_interval
     # get strides workouts
 
     def get_strides_workouts(self) -> list:
+        """Return the list of stride workouts."""
         return self.strides
     # get hill sprints workouts
 
     def get_hill_sprints_workouts(self) -> list:
+        """Return hill sprint workouts."""
         return self.hill_sprints
     # get flat sprints workouts
 
     def get_flat_sprints_workouts(self) -> list:
+        """Return flat sprint workouts."""
         return self.flat_sprints
     # get time trial workouts
 
     def get_time_trial_workouts(self) -> list:
+        """Return time trial workouts."""
         return self.time_trial
     # get warmup and cooldown workouts
 
     def get_warmup_and_cooldown(self) -> list:
+        """Return warmup and cooldown workouts."""
         return self.warmup_and_cooldown


### PR DESCRIPTION
## Summary
- reformat survey helpers with colon-based sections
- document database connection helpers using Args/Returns/Raises
- clarify data retrieval logic with structured docstrings
- reformat send helpers and pacing utilities for consistency
- update credential checks and day plan constructor docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: psycopg2, pandas, DB_CREDENTIALS)*

------
https://chatgpt.com/codex/tasks/task_e_688d440b3c6c83279247f51fc69df4b6