### PR TITLE
Refactor API client with shared instance and configurable base URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ __pycache__/
 *.build/
 
 *.log
+
+# Ignore local API configuration
+mobile/TrainingPlan/Resources/APIConfig.plist

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # AI Training Plans
 This project focuses on artificially generating training plans for the 5k/10k distances across Intermediate and Advanced experience levels. Project was began in June 2025.
+
+## Mobile API Configuration
+
+The iOS client expects a `mobile/TrainingPlan/Resources/APIConfig.plist` file
+containing an `API_BASE_URL` key pointing at your backend server. Copy the
+provided `APIConfig.plist.example` to `APIConfig.plist` and edit the URL to
+match your environment. The value can also be overridden with the
+`API_BASE_URL` environment variable at runtime.

--- a/mobile/TrainingPlan/Deprecated/SignUpViewDeprecated.swift
+++ b/mobile/TrainingPlan/Deprecated/SignUpViewDeprecated.swift
@@ -91,7 +91,7 @@ struct SignUpView: View {
                     username: username,
                     password: password)
                   do {
-                    let result = try await APIClient.signup(payload)
+                    let result = try await APIClient.shared.signup(payload)
                     isLoading = false
 
                     if let userId = result.user_id {

--- a/mobile/TrainingPlan/Info.plist
+++ b/mobile/TrainingPlan/Info.plist
@@ -16,22 +16,10 @@
 	<string>LaunchScreen</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSAllowsLocalNetworking</key>
-		<true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>100.113.243.28</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-				<key>New item</key>
-				<string></string>
-			</dict>
-		</dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
 	</dict>
 	<key>UIAppFonts</key>
 	<array>

--- a/mobile/TrainingPlan/Resources/APIConfig.plist.example
+++ b/mobile/TrainingPlan/Resources/APIConfig.plist.example
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>API_BASE_URL</key>
+    <string>http://localhost:8000</string>
+</dict>
+</plist>

--- a/mobile/TrainingPlan/Services/APIClient.swift
+++ b/mobile/TrainingPlan/Services/APIClient.swift
@@ -7,87 +7,115 @@ enum APIError: Error {
   case jsonDecoding(Error)
 }
 
-class APIClient {
-  static let baseURL = "http://100.113.243.28:8000"
+/// `APIClient` centralizes all network communication with the backend.
+///
+/// The client exposes async functions for each API call and uses a single
+/// `URLSession` instance under the hood. The base URL is resolved from an
+/// `APIConfig.plist` file in the application bundle, falling back to the
+/// `API_BASE_URL` environment variable and finally `http://localhost:8000`.
+final class APIClient {
+  static let shared = APIClient()
 
-  /// Sends the survey and returns the raw JSON as a dictionary.
-  static func submitPrelim(_ survey: SurveyIn) async throws -> [String: Any] {
-    guard let url = URL(string: "\(baseURL)/survey/prelim") else {
-      throw APIError.badURL
+  /// Resolve the base URL from a configuration file or environment variable.
+  private let baseURL: URL = {
+    if
+      let url = Bundle.main.url(forResource: "APIConfig", withExtension: "plist"),
+      let data = try? Data(contentsOf: url),
+      let dict = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any],
+      let base = dict["API_BASE_URL"] as? String,
+      let urlObj = URL(string: base)
+    {
+      return urlObj
     }
-    var req = URLRequest(url: url)
-    req.httpMethod = "POST"
-    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    req.httpBody = try JSONEncoder().encode(survey)
 
-    let (data, resp): (Data, URLResponse)
+    if let env = ProcessInfo.processInfo.environment["API_BASE_URL"],
+       let urlObj = URL(string: env) {
+      return urlObj
+    }
+
+    return URL(string: "http://localhost:8000")!
+  }()
+
+  private let session: URLSession
+
+  private init(session: URLSession = .shared) {
+    self.session = session
+  }
+
+  /// Generic request helper used by the public API methods below.
+  private func sendRequest(
+    _ path: String,
+    method: String = "GET",
+    body: Data? = nil,
+    queryItems: [URLQueryItem] = []
+  ) async throws -> Data {
+    var components = URLComponents(url: baseURL.appendingPathComponent(path), resolvingAgainstBaseURL: false)
+    components?.queryItems = queryItems.isEmpty ? nil : queryItems
+
+    guard let url = components?.url else { throw APIError.badURL }
+
+    var req = URLRequest(url: url)
+    req.httpMethod = method
+    if let body = body {
+      req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+      req.httpBody = body
+    }
+
     do {
-      (data, resp) = try await URLSession.shared.data(for: req)
+      let (data, resp) = try await session.data(for: req)
+      guard let http = resp as? HTTPURLResponse else { throw APIError.http(-1, data) }
+      guard 200..<300 ~= http.statusCode else { throw APIError.http(http.statusCode, data) }
+      return data
     } catch {
       throw APIError.network(error)
     }
-    guard let http = resp as? HTTPURLResponse else {
-      throw APIError.http(-1, data)
-    }
-    guard 200..<300 ~= http.statusCode else {
-      throw APIError.http(http.statusCode, data)
-    }
-    // parse into [String:Any]
+  }
+
+  /// Sends the survey and returns the raw JSON as a dictionary.
+  func submitPrelim(_ survey: SurveyIn) async throws -> [String: Any] {
+    let data = try await sendRequest(
+      "survey/prelim",
+      method: "POST",
+      body: try JSONEncoder().encode(survey)
+    )
+
     do {
       let obj = try JSONSerialization.jsonObject(with: data)
-      guard let dict = obj as? [String: Any] else {
-        return [:]
-      }
-      return dict
+      return obj as? [String: Any] ?? [:]
     } catch {
       throw APIError.jsonDecoding(error)
     }
   }
 
-  static func fetchHomeData(session: Session) async throws -> HomeData {
+  /// Retrieves the Home page data for the given session.
+  func fetchHomeData(session: Session) async throws -> HomeData {
     guard let userID = session.userID else {
       throw APIError.http(-1, Data("No userID in session".utf8))
     }
 
-    guard let url = URL(string: "\(baseURL)/home/data?user_id=\(userID)") else {
-      throw APIError.badURL
-    }
-    let (data, resp) = try await URLSession.shared.data(from: url)
-    guard let http = resp as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
-      throw APIError.http((resp as? HTTPURLResponse)?.statusCode ?? -1, data)
-    }
+    let data = try await sendRequest(
+      "home/data",
+      queryItems: [URLQueryItem(name: "user_id", value: String(userID))]
+    )
     return try JSONDecoder().decode(HomeData.self, from: data)
   }
 
-  static func signup(_ payload: SignupIn) async throws -> AuthOut {
-    guard let url = URL(string: "\(baseURL)/auth/signup") else {
-      throw APIError.badURL
-    }
-    var req = URLRequest(url: url)
-    req.httpMethod = "POST"
-    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    req.httpBody = try JSONEncoder().encode(payload)
-
-    let (data, resp) = try await URLSession.shared.data(for: req)
-    guard let http = resp as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
-      throw APIError.http((resp as? HTTPURLResponse)?.statusCode ?? -1, data)
-    }
+  func signup(_ payload: SignupIn) async throws -> AuthOut {
+    let data = try await sendRequest(
+      "auth/signup",
+      method: "POST",
+      body: try JSONEncoder().encode(payload)
+    )
     return try JSONDecoder().decode(AuthOut.self, from: data)
   }
 
-  static func login(_ payload: LoginIn) async throws -> AuthOut {
-    guard let url = URL(string: "\(baseURL)/auth/login") else {
-      throw APIError.badURL
-    }
-    var req = URLRequest(url: url)
-    req.httpMethod = "POST"
-    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    req.httpBody = try JSONEncoder().encode(payload)
-
-    let (data, resp) = try await URLSession.shared.data(for: req)
-    guard let http = resp as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
-      throw APIError.http((resp as? HTTPURLResponse)?.statusCode ?? -1, data)
-    }
+  func login(_ payload: LoginIn) async throws -> AuthOut {
+    let data = try await sendRequest(
+      "auth/login",
+      method: "POST",
+      body: try JSONEncoder().encode(payload)
+    )
     return try JSONDecoder().decode(AuthOut.self, from: data)
   }
 }
+

--- a/mobile/TrainingPlan/ViewModels/HomeViewModel.swift
+++ b/mobile/TrainingPlan/ViewModels/HomeViewModel.swift
@@ -8,7 +8,7 @@ class HomeViewModel: ObservableObject {
   func load(session: Session) async {
     // print("[HomeViewModel] load() called")
     do {
-      homeData = try await APIClient.fetchHomeData(session: session)
+      homeData = try await APIClient.shared.fetchHomeData(session: session)
     } catch {
       errorMessage = error.localizedDescription
     }

--- a/mobile/TrainingPlan/ViewModels/SurveyViewModel.swift
+++ b/mobile/TrainingPlan/ViewModels/SurveyViewModel.swift
@@ -43,7 +43,7 @@ class SurveyViewModel: ObservableObject {
     )
 
     do {
-      let result = try await APIClient.submitPrelim(survey)
+      let result = try await APIClient.shared.submitPrelim(survey)
       response = result
     } catch APIError.badURL {
       errorMessage = "Invalid server URL."

--- a/mobile/TrainingPlan/Views/LoginView.swift
+++ b/mobile/TrainingPlan/Views/LoginView.swift
@@ -98,7 +98,7 @@ struct LoginView: View {
                           username: username,
                           password: password)
                         do {
-                          let result = try await APIClient.login(payload)
+                          let result = try await APIClient.shared.login(payload)
                           isLoading = false
 
                           if let userId = result.user_id {

--- a/mobile/TrainingPlan/Views/SignUpView.swift
+++ b/mobile/TrainingPlan/Views/SignUpView.swift
@@ -113,7 +113,7 @@ struct SignUpView: View {
                           username: username,
                           password: password)
                         do {
-                          let result = try await APIClient.signup(payload)
+                          let result = try await APIClient.shared.signup(payload)
                           isLoading = false
 
                           if let userId = result.user_id {


### PR DESCRIPTION
## Summary
- centralize API calls into a shared `APIClient` with base URL read from `APIConfig.plist` or `API_BASE_URL` env var
- provide example `APIConfig.plist` and document how to override the base URL
- remove hard-coded IP from network security settings

## Testing
- `swiftc -typecheck mobile/TrainingPlan/Services/APIClient.swift mobile/TrainingPlan/Models/AuthModels.swift mobile/TrainingPlan/Models/SurveyModels.swift mobile/TrainingPlan/Models/HomeModels.swift mobile/TrainingPlan/utils/Session.swift` *(fails: no such module 'Combine')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2'; ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688e67b07574832782869f25a314966b