### PR TITLE
Improve database and email validation resilience

### DIFF
--- a/backend/src/utils/user_creation.py
+++ b/backend/src/utils/user_creation.py
@@ -16,7 +16,7 @@ except Exception:  # pragma: no cover
 
         pass
 
-    def validate_email(addr: str) -> None:
+    def validate_email(addr: str, **kwargs) -> None:
         """Validate an email address using a minimal heuristic.
 
         The fallback simply ensures there is an ``@`` symbol and a period in
@@ -66,7 +66,13 @@ def validate_address(email: str):
         bool: ``True`` if the address is valid, ``False`` otherwise.
     """
     try:
-        validate_email(email)
+        # ``email_validator`` checks DNS records by default which can make
+        # simple unit tests fail when using placeholder domains such as
+        # ``example.com``.  Disable deliverability checks so that we only
+        # validate the syntactic structure of the address.  The fallback
+        # implementation above accepts arbitrary keyword arguments so this
+        # call works whether or not the third-party library is installed.
+        validate_email(email, check_deliverability=False)
         return True
     except EmailNotValidError:
         return False

--- a/backend/src/utils/user_storage/user.py
+++ b/backend/src/utils/user_storage/user.py
@@ -148,7 +148,15 @@ class user:
 
         conn = init_db(DB_CREDENTIALS["DB_USERNAME"],
                        DB_CREDENTIALS["DB_PASSWORD"])
-        curr = conn.cursor()
+        if conn is None:
+            # ``init_db`` returns ``None`` when the connection attempt fails.
+            raise RuntimeError("Database utilities are not configured")
+
+        try:
+            curr = conn.cursor()
+        except Exception as e:  # pragma: no cover - defensive safety net
+            conn.close()
+            raise RuntimeError("Database utilities are not configured") from e
 
         try:
             # Check if the user_id exists in the user_credentials table


### PR DESCRIPTION
## Summary
- make `user_id_exists` raise `RuntimeError` when the database connection isn't available
- relax email validation by allowing fallback validator kwargs and skipping deliverability checks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e79f207ec8327b271510612084a41