### PR TITLE
feat: secure API connectivity

### DIFF
--- a/mobile/TrainingPlan/Info.plist
+++ b/mobile/TrainingPlan/Info.plist
@@ -14,13 +14,21 @@
 	<string>1.0</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-        <key>NSAllowsArbitraryLoads</key>
-        <true/>
+        <key>NSAppTransportSecurity</key>
+        <dict>
+        <key>NSExceptionDomains</key>
+        <dict>
+                <key>localhost</key>
+                <dict>
+                        <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                        <true/>
+                        <key>NSIncludesSubdomains</key>
+                        <true/>
+                </dict>
+        </dict>
         <key>NSAllowsLocalNetworking</key>
         <true/>
-	</dict>
+        </dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>MADEOkineSansPERSONALUSE-Black.otf</string>

--- a/mobile/TrainingPlan/Services/APIClient.swift
+++ b/mobile/TrainingPlan/Services/APIClient.swift
@@ -12,7 +12,7 @@ enum APIError: Error {
 /// The client exposes async functions for each API call and uses a single
 /// `URLSession` instance under the hood. The base URL is resolved from an
 /// `APIConfig.plist` file in the application bundle, falling back to the
-/// `API_BASE_URL` environment variable and finally `http://localhost:8000`.
+/// `API_BASE_URL` environment variable and finally a build-specific default.
 final class APIClient {
   static let shared = APIClient()
 
@@ -33,13 +33,21 @@ final class APIClient {
       return urlObj
     }
 
+    #if DEBUG
     return URL(string: "http://localhost:8000")!
+    #else
+    return URL(string: "https://localhost:8000")!
+    #endif
   }()
 
   private let session: URLSession
 
   private init(session: URLSession = .shared) {
     self.session = session
+#if !DEBUG
+    precondition(baseURL.scheme?.lowercased() == "https",
+                 "APIClient requires an HTTPS base URL in release builds.")
+#endif
   }
 
   /// Generic request helper used by the public API methods below.

--- a/run.sh
+++ b/run.sh
@@ -1,16 +1,25 @@
 set -e
 
 LOGFILE="$(pwd)/logs/uvicorn.log"
-PORT=8000
+PORT=${PORT:-8000}
 
-# pkill -f "uvicorn.*api:app" 2>/dev/null || true
-
-lsof -tiTCP:8000 -sTCP:LISTEN | xargs kill -9 || true
+# Terminate any process using the target port
+lsof -tiTCP:$PORT -sTCP:LISTEN | xargs kill -9 2>/dev/null || true
 
 sleep 0.2
-echo "Starting FastAPI backend..."
+
+echo "Starting FastAPI backend on port $PORT..."
+
+SSL_CERTFILE=${SSL_CERTFILE:-}
+SSL_KEYFILE=${SSL_KEYFILE:-}
+SSL_ARGS=""
+if [ -n "$SSL_CERTFILE" ] && [ -n "$SSL_KEYFILE" ]; then
+  SSL_ARGS="--ssl-certfile $SSL_CERTFILE --ssl-keyfile $SSL_KEYFILE"
+fi
+
 mkdir -p "$(dirname "$LOGFILE")"
 nohup python3 -u -m uvicorn backend.src.main.API.api:app \
-    --reload --host 0.0.0.0 --port 8000 \
+    --reload --host 0.0.0.0 --port "$PORT" $SSL_ARGS \
     > "$LOGFILE" 2>&1 &
-echo "API started (pid $!) and logging to "$LOGFILE""
+
+echo "API started (pid $!) and logging to $LOGFILE"


### PR DESCRIPTION
## Summary
- secure run script adds optional TLS parameters and dynamic port
- tighten iOS ATS rules and require HTTPS base URL in release

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ea306b80c8327a7f87970b3dce8c6