### PR TITLE
Sanitise logging of sensitive data

### DIFF
--- a/backend/src/main/API/api.py
+++ b/backend/src/main/API/api.py
@@ -117,9 +117,9 @@ async def survey_prelim(payload: SurveyIn):
 
         return result
     except Exception as e:
-        # surface errors as HTTP 500 and log to the log file
+        # surface errors as HTTP 500 and log to the log file without exposing sensitive data
         logger.exception(
-            "Unexpected error in /survey/prelim with payload=%r", payload)
+            "Unexpected error in /survey/prelim for user_id=%s", payload.user_id)
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -272,9 +272,9 @@ async def signup(payload: SignupIn):
         # Error code 1 indicates the email exists
 
     except Exception as e:
-        # surface errors as HTTP 500, but log the goddamn errors somewhere
+        # surface errors as HTTP 500, but avoid logging sensitive signup details
         logger.exception(
-            "Unexpected error in /auth/signup with payload=%r", payload)
+            "Unexpected error in /auth/signup for username=%s", payload.username)
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -301,9 +301,9 @@ async def login(payload: LoginIn):
 
         return AuthOut(user_id=userid)
     except Exception as e:
-        # surface errors as HTTP 500
+        # surface errors as HTTP 500 while redacting login credentials
         logger.exception(
-            "Unexpected error in /auth/login with payload=%r", payload)
+            "Unexpected error in /auth/login for username=%s", payload.username)
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/backend/src/utils/SQLutils/database_connect.py
+++ b/backend/src/utils/SQLutils/database_connect.py
@@ -30,7 +30,7 @@ def init_db(username, pwd):
         else:
             locate = "localhost"
         # Establish connection
-        print(username, pwd, locate)
+        logger.debug("Connecting to database at %s as user %s", locate, username)
         conn = psycopg2.connect(database="userdatabase",
                                 user=username,
                                 host=locate,

--- a/backend/src/utils/user_storage/user.py
+++ b/backend/src/utils/user_storage/user.py
@@ -179,13 +179,13 @@ class user:
         # Generate a new user ID
         new_user_id = secrets.randbelow(90000000) + 10000000
 
-        # Check if the user ID already exists in the database
+        # Check if the user ID already exists in the database when configured
         if init_db is not None and DB_CREDENTIALS:
             if user.user_id_exists(new_user_id):
                 logger.warning("User ID already exists, generating a new one.")
-                user.generate_new_id()
-            else:
-                return new_user_id
+                return user.generate_new_id()
+
+        return new_user_id
 
     def get_age(self) -> int:
         """Returns the number of years the user has been alive as an int"""


### PR DESCRIPTION
## Summary
- Avoid logging entire request payloads in survey and auth handlers
- Remove plaintext credential print and switch to debug-level connection log
- Ensure generated user IDs return even without database configuration

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ed8bfcd448327b19471adc5ef7c0d