### PR TITLE
Allow insecure HTTP to testing IP

### DIFF
--- a/mobile/TrainingPlan/Info.plist
+++ b/mobile/TrainingPlan/Info.plist
@@ -18,8 +18,18 @@
         <dict>
                 <key>NSAllowsLocalNetworking</key>
                 <true/>
+                <key>NSExceptionDomains</key>
+                <dict>
+                        <key>100.113.243.28</key>
+                        <dict>
+                                <key>NSIncludesSubdomains</key>
+                                <true/>
+                                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                                <true/>
+                        </dict>
+                </dict>
         </dict>
-	<key>UIAppFonts</key>
+        <key>UIAppFonts</key>
 	<array>
 		<string>MADEOkineSansPERSONALUSE-Black.otf</string>
 		<string>MADEOkineSansPERSONALUSE-Medium.otf</string>


### PR DESCRIPTION
## Summary
- allow HTTP loads to testing IP 100.113.243.28 by adding NSExceptionDomains in Info.plist

## Testing
- `xcodebuild -project mobile/TrainingPlan/TrainingPlan.xcodeproj -scheme TrainingPlan -sdk iphonesimulator -quiet` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a61b9dbc08324b8ea43322165d64e