### PR TITLE
Add optional HTTP flag to run script for SSL control

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,22 @@
 set -e
 
-export SSL_CERTFILE=certifications/endorphin.crt
-export SSL_KEYFILE=certifications/endorphin.key
+USE_SSL=1
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -test|--http)
+      USE_SSL=0
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [ "$USE_SSL" -eq 1 ]; then
+  export SSL_CERTFILE=certifications/endorphin.crt
+  export SSL_KEYFILE=certifications/endorphin.key
+fi
 
 LOGFILE="$(pwd)/logs/uvicorn.log"
 PORT=${PORT:-8000}
@@ -13,18 +28,26 @@ sleep 0.2
 
 echo "Starting FastAPI backend on port $PORT..."
 
-SSL_CERTFILE=${SSL_CERTFILE:-}
-SSL_KEYFILE=${SSL_KEYFILE:-}
+if [ "$USE_SSL" -eq 1 ]; then
+  SSL_CERTFILE=${SSL_CERTFILE:-}
+  SSL_KEYFILE=${SSL_KEYFILE:-}
 
-if [ -z "$SSL_CERTFILE" ] || [ -z "$SSL_KEYFILE" ]; then
-  echo "SSL_CERTFILE and SSL_KEYFILE must be set for HTTPS connections." >&2
-  exit 1
+  if [ -z "$SSL_CERTFILE" ] || [ -z "$SSL_KEYFILE" ]; then
+    echo "SSL_CERTFILE and SSL_KEYFILE must be set for HTTPS connections." >&2
+    exit 1
+  fi
 fi
 
 mkdir -p "$(dirname "$LOGFILE")"
-nohup python3 -u -m uvicorn backend.src.main.API.api:app \
-    --reload --host 0.0.0.0 --port "$PORT" \
-    --ssl-certfile "$SSL_CERTFILE" --ssl-keyfile "$SSL_KEYFILE" \
-    > "$LOGFILE" 2>&1 &
+if [ "$USE_SSL" -eq 1 ]; then
+  nohup python3 -u -m uvicorn backend.src.main.API.api:app \
+      --reload --host 0.0.0.0 --port "$PORT" \
+      --ssl-certfile "$SSL_CERTFILE" --ssl-keyfile "$SSL_KEYFILE" \
+      > "$LOGFILE" 2>&1 &
+else
+  nohup python3 -u -m uvicorn backend.src.main.API.api:app \
+      --reload --host 0.0.0.0 --port "$PORT" \
+      > "$LOGFILE" 2>&1 &
+fi
 
 echo "API started (pid $!) and logging to $LOGFILE"


### PR DESCRIPTION
## Summary
- add USE_SSL toggle driven by -test/--http flag
- skip certificate validation and SSL args when HTTP mode enabled

## Testing
- `bash -n run.sh`
- `pytest` *(fails: TypeError: '<=' not supported between instances of 'int' and 'NoneType')*

------
https://chatgpt.com/codex/tasks/task_e_689a61b26ee08324b85e7397bc1c1fb1