### PR TITLE
docs: add first-time setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,40 @@
 # AI Training Plans
 This project focuses on artificially generating training plans for the 5k/10k distances across Intermediate and Advanced experience levels. Project was began in June 2025.
 
+## First-Time Setup
+
+If you're getting started with the project for the first time, follow these steps:
+
+1. **Install backend dependencies**
+
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -r backend/requirements/base.txt
+   ```
+
+2. **Create required config files**
+
+   ```bash
+   cp mobile/TrainingPlan/Resources/APIConfig.plist.example mobile/TrainingPlan/Resources/APIConfig.plist
+   cp backend/src/utils/SQLutils/config.py.example backend/src/utils/SQLutils/config.py
+   ```
+
+   Edit the copied files to match your environment (see sections below for details).
+
+3. **Run the backend**
+
+   ```bash
+   ./run.sh           # uses HTTPS
+   ./run.sh --http    # run without SSL for local testing
+   ```
+
+4. **Verify the setup** (optional)
+
+   ```bash
+   pytest
+   ```
+
 ## Mobile API Configuration
 
 The iOS client expects a `mobile/TrainingPlan/Resources/APIConfig.plist` file


### PR DESCRIPTION
## Summary
- document first-time setup steps for dependencies, config files, and starting the backend

## Testing
- `pytest` *(fails: TypeError in utils_test.py::test_user_rpe_and_predictions)*

------
https://chatgpt.com/codex/tasks/task_e_689a65af26b083249cff25f0328678d7