### PR TITLE
Use .env for backend configuration and document setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+API_KEY=your_api_key_here
+DB_USERNAME=your_db_username
+DB_PASSWORD=your_db_password
+DB_HOST=localhost

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-# Ignore sensitive files
-backend/src/utils/SQLutils/config.py
-
 # Ignore Python cache files
 __pycache__/
 *.pyc
+
+# Environment variables and virtual environments
+.env
+.venv/
 .pytest_cache/
 
 # Ignore vscode files

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ If you're getting started with the project for the first time, follow these step
    pip install -r backend/requirements/base.txt
    ```
 
-2. **Create required config files**
+2. **Create environment files**
 
    ```bash
+   cp .env.example .env
    cp mobile/TrainingPlan/Resources/APIConfig.plist.example mobile/TrainingPlan/Resources/APIConfig.plist
-   cp backend/src/utils/SQLutils/config.py.example backend/src/utils/SQLutils/config.py
    ```
 
-   Edit the copied files to match your environment (see sections below for details).
+   Update `.env` and `APIConfig.plist` to match your environment (see sections below for details).
 
 3. **Run the backend**
 
@@ -48,8 +48,7 @@ can reach the server.
 
 ## Backend Database Configuration
 
-The backend expects a `backend/src/utils/SQLutils/config.py` file defining a
-`DB_CREDENTIALS` dictionary with the database connection details. Copy the
-provided `config.py.example` to `config.py` and fill in your `DB_USERNAME`,
-`DB_PASSWORD`, and database `host` values so the application can connect to
-your PostgreSQL instance.
+Database credentials are loaded from environment variables defined in the
+project's `.env` file. The `backend/src/utils/SQLutils/config.py` module uses
+`pydantic` to read `DB_USERNAME`, `DB_PASSWORD`, and `DB_HOST` values and makes
+them available through the `DB_CREDENTIALS` dictionary.

--- a/backend/src/utils/SQLutils/config.py
+++ b/backend/src/utils/SQLutils/config.py
@@ -1,0 +1,26 @@
+"""Load application settings from environment variables."""
+
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    """Application settings loaded from a `.env` file or environment variables."""
+
+    api_key: str | None = None
+    db_username: str = ""
+    db_password: str = ""
+    db_host: str = "localhost"
+
+    class Config:
+        env_file = ".env"
+
+settings = Settings()
+
+DB_CREDENTIALS = {
+    "DB_USERNAME": settings.db_username,
+    "DB_PASSWORD": settings.db_password,
+    "host": settings.db_host,
+}
+
+API_KEY = settings.api_key
+
+__all__ = ["DB_CREDENTIALS", "API_KEY", "settings"]


### PR DESCRIPTION
## Summary
- load DB and API settings from environment variables via pydantic
- ignore `.env` and virtual environments in git
- document creating `.env` and venv in the README

## Testing
- `pytest` *(fails: No module named 'psycopg2'; No module named 'bcrypt')*


------
https://chatgpt.com/codex/tasks/task_e_689b824226308324b71ce69ccfef7b88