### PR TITLE
Improve config and debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ can reach the server.
 ## Backend Database Configuration
 
 Database credentials are loaded from environment variables defined in the
-project's `.env` file. The `backend/src/utils/SQLutils/config.py` module uses
-`pydantic` to read `DB_USERNAME`, `DB_PASSWORD`, and `DB_HOST` values and makes
-them available through the `DB_CREDENTIALS` dictionary.
+project's `.env` file. The `backend/config.py` module uses `pydantic` to read
+`DB_USERNAME`, `DB_PASSWORD`, and `DB_HOST` values and makes them available
+through the `DB_CREDENTIALS` dictionary. A `SECRET_KEY` is also read from the
+environment for signing authentication tokens; ensure this value is set before
+running the API.

--- a/backend/config.py
+++ b/backend/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     db_username: str = ""
     db_password: str = ""
     db_host: str = "localhost"
+    secret_key: str = ""
 
     class Config:
         env_file = ".env"


### PR DESCRIPTION
## Summary
- load `SECRET_KEY` from unified config
- enhance request, token, and auth endpoint debug logging while scrubbing sensitive data
- allow HTTP/CORS in debug and document new environment variables

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689b97f19afc83248510dbd90e89c8bc