### PR TITLE
Use cookies for authentication

### DIFF
--- a/mobile/TrainingPlan/Models/AuthModels.swift
+++ b/mobile/TrainingPlan/Models/AuthModels.swift
@@ -11,13 +11,7 @@ struct LoginIn: Codable {
   let password: String
 }
 
-struct RefreshIn: Codable {
-  let refresh_token: String
-}
-
 struct AuthOut: Codable {
   let user_id: Int?
   let error_code: Int?
-  let access_token: String?
-  let refresh_token: String?
 }


### PR DESCRIPTION
## Summary
- drop Authorization header support in API and rely on HTTP-only cookies
- update Swift client and models to stop handling bearer tokens

## Testing
- `pytest`
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689bacfa428c832491aa0766f7bb6c31