### PR TITLE
Run backend via cmd.exe to capture combined logs

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -60,15 +60,16 @@ if ($USE_SSL -and (-not $env:SSL_CERTFILE -or -not $env:SSL_KEYFILE)) {
 $logDir = Split-Path $LOGFILE
 New-Item -ItemType Directory -Force -Path $logDir | Out-Null
 
-$arguments = "-u -m uvicorn backend.src.main.API.api:app $RELOAD --host 0.0.0.0 --port $PORT --log-level $UVICORN_LOG_LEVEL $ACCESS_LOG"
+$cmd = "python -u -m uvicorn backend.src.main.API.api:app $RELOAD --host 0.0.0.0 --port $PORT --log-level $UVICORN_LOG_LEVEL $ACCESS_LOG"
 if ($USE_SSL) {
-    $arguments += " --ssl-certfile `"$env:SSL_CERTFILE`" --ssl-keyfile `"$env:SSL_KEYFILE`""
+    $cmd += " --ssl-certfile `"$env:SSL_CERTFILE`" --ssl-keyfile `"$env:SSL_KEYFILE`""
 }
 
-$process = Start-Process -FilePath "python" -ArgumentList $arguments -RedirectStandardOutput $LOGFILE -RedirectStandardError $LOGFILE -NoNewWindow -PassThru
+$process = Start-Process -FilePath "cmd.exe" -ArgumentList "/c $cmd >> `"$LOGFILE`" 2>>&1" -NoNewWindow -PassThru
 
 if (-not $USE_SSL) {
     Write-Warning "!!! WARNING: INSECURE !!!"
 }
 
-Write-Host "API started (pid $($process.Id)) and logging to $LOGFILE"
+Write-Host "API started (cmd.exe pid $($process.Id)) and logging to $LOGFILE"
+Write-Host "Use `"Get-Process -Name python | Select-Object -Last 1`" if the Python PID is required."


### PR DESCRIPTION
## Summary
- start FastAPI via `cmd.exe` so stdout and stderr append to one log file
- clarify that reported PID belongs to `cmd.exe` wrapper

## Testing
- `pwsh -NoProfile -File run.ps1 -Test` *(fails: pwsh not installed)*
- `apt-get install -y powershell` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e375f7ba883249be4e75735c846b9